### PR TITLE
Add support for specifying a `DispatchQueue` for underlying live queries to use for callbacks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,6 @@
 
 osx_image: xcode7.3
 language: objective-c
-# cache: cocoapods
-# podfile: Example/Podfile
-# before_install:
-# - gem install cocoapods # Since Travis is not always on latest version
-# - pod install --project-directory=Example
 script:
-- set -o pipefail && xcodebuild test -enableCodeCoverage YES -workspace Example/RxSwiftDitto.xcworkspace -scheme RxSwiftDitto-Example -sdk iphonesimulator9.3 ONLY_ACTIVE_ARCH=NO | xcpretty
-- pod lib lint
+  - set -o pipefail && xcodebuild test -enableCodeCoverage YES -workspace Example/RxSwiftDitto.xcworkspace -scheme RxSwiftDitto-Example -sdk iphonesimulator9.3 ONLY_ACTIVE_ARCH=NO | xcpretty
+  - pod lib lint

--- a/Example/Helper.swift
+++ b/Example/Helper.swift
@@ -11,9 +11,9 @@ import Foundation
 struct Helper {
 
     static var licenseToken: String {
-        let path = Bundle.main.path(forResource: "license_token", ofType: "txt") // file path for file "data.txt"
+        let path = Bundle.main.path(forResource: "license_token", ofType: "txt")
         guard let text = try? String(contentsOfFile: path!) else {
-            fatalError("please add a file called license_token.txt to the bundle and paste a valid Ditto license token")
+            fatalError("please add a file called license_token.txt to the bundle containing a valid Ditto license token")
         }
         return text
     }

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -3,14 +3,15 @@ use_frameworks!
 platform :ios, '12.0'
 
 target 'RxSwiftDitto_Example' do
-  pod 'RxSwiftDitto', :path => '../'
-  pod 'RxCocoa', '~> 6.1.0'
+  pod 'RxSwiftDitto', path: '../'
+  pod 'RxCocoa', '~> 6.5.0'
   pod 'RxDataSources', '~> 5.0.0'
   pod 'Fakery', '=5.1.0'
+  pod 'DittoSwift', '1.1.5'
 
   target 'RxSwiftDitto_Tests' do
     inherit! :search_paths
     pod 'Fakery', '=5.1.0'
-    
+
   end
 end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,26 +1,27 @@
 PODS:
   - Differentiator (5.0.0)
-  - DittoObjC (1.0.14)
-  - DittoSwift (1.0.14):
-    - DittoObjC (= 1.0.14)
+  - DittoObjC (1.1.5)
+  - DittoSwift (1.1.5):
+    - DittoObjC (= 1.1.5)
   - Fakery (5.1.0)
-  - RxCocoa (6.1.0):
-    - RxRelay (= 6.1.0)
-    - RxSwift (= 6.1.0)
+  - RxCocoa (6.5.0):
+    - RxRelay (= 6.5.0)
+    - RxSwift (= 6.5.0)
   - RxDataSources (5.0.0):
     - Differentiator (~> 5.0)
     - RxCocoa (~> 6.0)
     - RxSwift (~> 6.0)
-  - RxRelay (6.1.0):
-    - RxSwift (= 6.1.0)
-  - RxSwift (6.1.0)
-  - RxSwiftDitto (1.0.0):
-    - DittoSwift (>= 1.0.13)
-    - RxSwift (>= 6.0.0)
+  - RxRelay (6.5.0):
+    - RxSwift (= 6.5.0)
+  - RxSwift (6.5.0)
+  - RxSwiftDitto (1.0.1):
+    - DittoSwift (~> 1.0)
+    - RxSwift (~> 6.0)
 
 DEPENDENCIES:
+  - DittoSwift (= 1.1.5)
   - Fakery (= 5.1.0)
-  - RxCocoa (~> 6.1.0)
+  - RxCocoa (~> 6.5.0)
   - RxDataSources (~> 5.0.0)
   - RxSwiftDitto (from `../`)
 
@@ -41,15 +42,15 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Differentiator: e8497ceab83c1b10ca233716d547b9af21b9344d
-  DittoObjC: f92e809503af2b2bef7d430038f29987b3fabfff
-  DittoSwift: 94419444fc8a2c9825f81d6db978fbedd22539b1
+  DittoObjC: a86202b321a4e49953d36ba554e8c66f5c56a3b3
+  DittoSwift: 40ce7f009d961f05815060b5f701ecb99d15e3be
   Fakery: a90caff00ca5cacde6c161c3eafc72314a03d34d
-  RxCocoa: 5c51f02d562cbd94629f6c26cf0c80fe4ab8d343
+  RxCocoa: 94f817b71c07517321eb4f9ad299112ca8af743b
   RxDataSources: aa47cc1ed6c500fa0dfecac5c979b723542d79cf
-  RxRelay: 483e1a19fad961b41f0b0c0bee506f46c1ae14fe
-  RxSwift: a834e5c538e89eca0cae86f403f4fbf0336786ce
-  RxSwiftDitto: c929b7288cef1c7b91346f47b6d95ae86e62e10e
+  RxRelay: 1de1523e604c72b6c68feadedd1af3b1b4d0ecbd
+  RxSwift: 5710a9e6b17f3c3d6e40d6e559b9fa1e813b2ef8
+  RxSwiftDitto: 7ae6be3dcc4975c41422c91fdc2b4bf73b4b248f
 
-PODFILE CHECKSUM: a94a92b63c4051ebf107d165c32c3edd092e5315
+PODFILE CHECKSUM: cc38719dd99cf4d1da0116cf078a75a92d7b4cbc
 
 COCOAPODS: 1.11.2

--- a/Example/RxSwiftDitto/AppDelegate.swift
+++ b/Example/RxSwiftDitto/AppDelegate.swift
@@ -27,8 +27,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // ditto setup
         Self.ditto = Ditto()
-        Self.ditto.setAccessLicense(Helper.licenseToken)
-        Self.ditto.startSync()
+        try! Self.ditto.setOfflineOnlyLicenseToken(Helper.licenseToken)
+        try! Self.ditto.tryStartSync()
 
         self.window = window
         return true

--- a/Example/RxSwiftDitto/RxDataSourcesCombineLatestViewController.swift
+++ b/Example/RxSwiftDitto/RxDataSourcesCombineLatestViewController.swift
@@ -77,13 +77,13 @@ class RxDataSourcesCombineLatestViewController: UIViewController {
                 if let randomCompany = companyDocs.map({ Company(document: $0) }).randomElement() {
                     companyId = randomCompany.id
                 } else {
-                    companyId = try! AppDelegate.ditto.store["companies"].insert([
+                    companyId = try! AppDelegate.ditto.store["companies"].upsert([
                         "title": faker.company.name(),
                         "details": faker.company.bs(),
                         "editedOn": ISO8601DateFormatter().string(from: Date()),
                     ]).toString()
                 }
-                try! AppDelegate.ditto.store["products"].insert([
+                try! AppDelegate.ditto.store["products"].upsert([
                     "title": faker.commerce.productName(),
                     "details": faker.lorem.paragraphs(amount:1),
                     "editedOn": ISO8601DateFormatter().string(from: Date()),

--- a/Example/RxSwiftDitto/RxDataSourcesDocumentsViewController.swift
+++ b/Example/RxSwiftDitto/RxDataSourcesDocumentsViewController.swift
@@ -63,7 +63,7 @@ class RxDataSourcesDocumentsViewController: UIViewController {
             .rx
             .tap
             .bind { _ in
-                try! AppDelegate.ditto.store["companies"].insert([
+                try! AppDelegate.ditto.store["companies"].upsert([
                     "title": Faker().company.name(),
                     "details": Faker().company.bs(),
                     "editedOn": ISO8601DateFormatter().string(from: Date())

--- a/README.md
+++ b/README.md
@@ -16,10 +16,6 @@ it, simply add the following line to your Podfile:
 pod 'RxSwiftDitto'
 ```
 
-### For testing...
-
-DittoSwift requires a license token in order to work properly. Please contact the Ditto team on at [contact@ditto.live](mailto:contact@ditto.live) to get access to a license token. This project loads a license token from a file `license_token.txt`. Once you've obtained a license token, you can create the file and paste it in. Once you open up `RxSwiftDitto.xcworkspace` you will see that the `license_token.txt` is part of the test target. Note: `license_token.txt` is part of the `.gitignore`. Ensure not to accidentally commit and push it up to this repo.
-
 ## Usage:
 
 Simple live queries with snapshots of `[DittoDocument]`

--- a/RxSwiftDitto.podspec
+++ b/RxSwiftDitto.podspec
@@ -1,36 +1,17 @@
-#
-# Be sure to run `pod lib lint RxSwiftDitto.podspec' to ensure this is a
-# valid spec before submitting.
-#
-# Any lines starting with a # are optional, but their use is encouraged
-# To learn more about a Podspec see https://guides.cocoapods.org/syntax/podspec.html
-#
-
 Pod::Spec.new do |s|
   s.name             = 'RxSwiftDitto'
-  s.version          = '1.0.0'
-  s.summary = "RxSwift extension methods around the DittoSwift library."
+  s.version          = '1.0.1'
+  s.summary          = "RxSwift extension methods around the DittoSwift library."
   s.homepage         = 'https://github.com/getditto/RxSwiftDitto'
-  s.license          = { :type => 'MIT', :file => 'LICENSE' }
+  s.license          = { type: 'MIT', file: 'LICENSE' }
   s.author           = { 'mbalex99' => 'max@ditto.live' }
-  s.source           = { :git => 'https://github.com/getditto/RxSwiftDitto.git', :tag => s.version.to_s }
+  s.source           = { git: 'https://github.com/getditto/RxSwiftDitto.git', tag: s.version.to_s }
   s.social_media_url = 'https://twitter.com/dittolive'
 
   s.ios.deployment_target = '12.0'
-  s.swift_version = '5.1'
 
   s.source_files = 'RxSwiftDitto/Classes/**/*'
 
-  # DittoSwift isn't available for all simulator types 
-  s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-  s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-  
-  # s.resource_bundles = {
-  #   'RxSwiftDitto' => ['RxSwiftDitto/Assets/*.png']
-  # }
-
-  # s.public_header_files = 'Pod/Classes/**/*.h'
-  # s.frameworks = 'UIKit', 'MapKit'
-  s.dependency 'RxSwift', '>= 6.0.0'
-  s.dependency 'DittoSwift', '>= 1.0.14'
+  s.dependency 'RxSwift', '~> 6.0'
+  s.dependency 'DittoSwift', '~> 1.0'
 end

--- a/RxSwiftDitto/Classes/DittoPendingIDSpecificOperation+Rx.swift
+++ b/RxSwiftDitto/Classes/DittoPendingIDSpecificOperation+Rx.swift
@@ -47,4 +47,18 @@ extension Reactive where Base: DittoPendingIDSpecificOperation {
             }
         }
     }
+
+    /**
+     * Returns an observable of the live query
+     */
+    public func liveQuery(deliverOn queue: DispatchQueue = .main) -> Observable<DittoDocumentWithLiveQueryEvent> {
+        return Observable.create { observer in
+            let l = self.base.observe(deliverOn: queue) { doc, event in
+                observer.onNext((doc, event))
+            }
+            return Disposables.create {
+                l.stop()
+            }
+        }
+    }
 }


### PR DESCRIPTION
Add support for specifying a `DispatchQueue` that you want the underlying Ditto
live query to use when calling the live query callbacks.
